### PR TITLE
Criação de documentação via Swagger #B003

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+/storage/api-docs

--- a/src/app/Http/Controllers/AtividadeController.php
+++ b/src/app/Http/Controllers/AtividadeController.php
@@ -6,10 +6,30 @@ use App\Models\Atividade;
 use Exception;
 use Illuminate\Http\Request;
 
+/**
+ * @OA\Tag(
+ *     name="Atividades",
+ *     description="Endpoints para gerenciar as atividades (tarefas com prazo)."
+ * )
+ */
 class AtividadeController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * @OA\Get(
+     *      path="/api/atividades",
+     *      operationId="getAtividadesList",
+     *      tags={"Atividades"},
+     *      summary="Lista todas as atividades",
+     *      description="Retorna uma lista de todas as atividades cadastradas com seus respectivos problemas detalhados.",
+     *      @OA\Response(
+     *          response=200,
+     *          description="Operação bem-sucedida",
+     *          @OA\JsonContent(
+     *              type="array",
+     *              @OA\Items(ref="#/components/schemas/AtividadeComProblema")
+     *          )
+     *      )
+     * )
      */
     public function index()
     {
@@ -19,7 +39,28 @@ class AtividadeController extends Controller
     }
 
     /**
-     * Store a newly created resource in storage.
+     * @OA\Post(
+     *      path="/api/atividades",
+     *      operationId="storeAtividade",
+     *      tags={"Atividades"},
+     *      summary="Cria uma nova atividade",
+     *      description="Cria uma nova atividade associando um problema e definindo uma data de entrega.",
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="Dados para a criação da atividade.",
+     *          @OA\JsonContent(
+     *              required={"data_entrega", "problema_id"},
+     *              @OA\Property(property="data_entrega", type="string", format="date-time", example="2024-06-01T23:59:00"),
+     *              @OA\Property(property="problema_id", type="integer", example=1)
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="Atividade criada com sucesso",
+     *          @OA\JsonContent(ref="#/components/schemas/Atividade")
+     *      ),
+     *      @OA\Response(response=422, description="Erro de validação dos dados")
+     * )
      */
     public function store(Request $request)
     {
@@ -29,7 +70,25 @@ class AtividadeController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * @OA\Get(
+     *      path="/api/atividades/{atividade}",
+     *      operationId="getAtividadeById",
+     *      tags={"Atividades"},
+     *      summary="Exibe uma atividade específica (Não Implementado)",
+     *      description="Este endpoint foi planejado, mas ainda não foi implementado.",
+     *      deprecated=true,
+     *      @OA\Parameter(
+     *          name="atividade",
+     *          in="path",
+     *          required=true,
+     *          description="ID da atividade",
+     *          @OA\Schema(type="integer")
+     *      ),
+     *      @OA\Response(
+     *          response=501,
+     *          description="Não Implementado"
+     *      )
+     * )
      */
     public function show(Atividade $atividade)
     {
@@ -37,7 +96,19 @@ class AtividadeController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
+     * @OA\Put(
+     *      path="/api/atividades/{atividade}",
+     *      operationId="updateAtividade",
+     *      tags={"Atividades"},
+     *      summary="Atualiza uma atividade (Não Implementado)",
+     *      description="Este endpoint foi planejado, mas ainda não foi implementado.",
+     *      deprecated=true,
+     *      @OA\Parameter(name="atividade", in="path", required=true, @OA\Schema(type="integer")),
+     *      @OA\Response(
+     *          response=501,
+     *          description="Não Implementado"
+     *      )
+     * )
      */
     public function update(Request $request, Atividade $atividade)
     {
@@ -45,7 +116,19 @@ class AtividadeController extends Controller
     }
 
     /**
-     * Remove the specified resource from storage.
+     * @OA\Delete(
+     *      path="/api/atividades/{atividade}",
+     *      operationId="deleteAtividade",
+     *      tags={"Atividades"},
+     *      summary="Remove uma atividade (Não Implementado)",
+     *      description="Este endpoint foi planejado, mas ainda não foi implementado.",
+     *      deprecated=true,
+     *      @OA\Parameter(name="atividade", in="path", required=true, @OA\Schema(type="integer")),
+     *      @OA\Response(
+     *          response=501,
+     *          description="Não Implementado"
+     *      )
+     * )
      */
     public function destroy(Atividade $atividade)
     {

--- a/src/app/Http/Controllers/Controller.php
+++ b/src/app/Http/Controllers/Controller.php
@@ -6,6 +6,18 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller as BaseController;
 
+/**
+ * @OA\Info(
+ *      version="1.0.0",
+ *      title="API de Submissões de Código",
+ *      description="Documentação da API para o sistema de submissão e avaliação de código. Este é um protótipo inicial."
+ * )
+ *
+ * @OA\Server(
+ *      url=L5_SWAGGER_CONST_HOST,
+ *      description="Servidor Principal da API"
+ * )
+ */
 class Controller extends BaseController
 {
     use AuthorizesRequests, ValidatesRequests;

--- a/src/app/Http/Controllers/ProblemaController.php
+++ b/src/app/Http/Controllers/ProblemaController.php
@@ -10,7 +10,21 @@ use Illuminate\Http\Request;
 class ProblemaController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * @OA\Get(
+     *      path="/api/problemas",
+     *      operationId="getProblemasList",
+     *      tags={"Problemas"},
+     *      summary="Lista todos os problemas",
+     *      description="Retorna uma lista de problemas, incluindo seus respectivos casos de teste.",
+     *      @OA\Response(
+     *          response=200,
+     *          description="Operação bem-sucedida",
+     *          @OA\JsonContent(
+     *              type="array",
+     *              @OA\Items(ref="#/components/schemas/ProblemaComCasosTeste")
+     *          )
+     *      )
+     * )
      */
     public function index()
     {
@@ -21,7 +35,46 @@ class ProblemaController extends Controller
     }
 
     /**
-     * Store a newly created resource in storage.
+     * @OA\Post(
+     *      path="/api/problemas",
+     *      operationId="storeProblema",
+     *      tags={"Problemas"},
+     *      summary="Cria um novo problema",
+     *      description="Cria um novo problema e seus casos de teste associados em uma única requisição.",
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="Dados do problema e seus casos de teste.",
+     *          @OA\JsonContent(
+     *              required={"titulo", "enunciado", "tempo_limite", "memoria_limite", "casos_teste"},
+     *              @OA\Property(property="titulo", type="string", example="Soma Simples"),
+     *              @OA\Property(property="enunciado", type="string", example="Faça um programa que some dois números."),
+     *              @OA\Property(property="tempo_limite", type="integer", example=1),
+     *              @OA\Property(property="memoria_limite", type="integer", example=1024),
+     *              @OA\Property(
+     *                  property="casos_teste",
+     *                  type="array",
+     *                  description="Lista de casos de teste para o problema.",
+     *                  @OA\Items(
+     *                      type="object",
+     *                      required={"entrada", "saida"},
+     *                      @OA\Property(property="entrada", type="string", example="1 2"),
+     *                      @OA\Property(property="saida", type="string", example="3"),
+     *                      @OA\Property(property="privado", type="boolean", description="Define se o caso de teste é público (false) ou privado (true). O padrão é false se não for enviado.", example=false)
+     *                  )
+     *              )
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="Problema criado com sucesso",
+     *          @OA\JsonContent(ref="#/components/schemas/Problema")
+     *      ),
+     *      @OA\Response(
+     *          response=400,
+     *          description="Erro ao salvar",
+     *          @OA\JsonContent(type="string", example="Erro ao salvar!")
+     *      )
+     * )
      */
     public function store(Request $request)
     {
@@ -35,7 +88,26 @@ class ProblemaController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * @OA\Get(
+     *      path="/api/problemas/{problema}",
+     *      operationId="getProblemaById",
+     *      tags={"Problemas"},
+     *      summary="Exibe um problema específico",
+     *      description="Retorna os dados de um único problema, sem os casos de teste.",
+     *      @OA\Parameter(
+     *          name="problema",
+     *          in="path",
+     *          required=true,
+     *          description="ID do problema",
+     *          @OA\Schema(type="integer")
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Operação bem-sucedida",
+     *          @OA\JsonContent(ref="#/components/schemas/Problema")
+     *      ),
+     *      @OA\Response(response=404, description="Problema não encontrado")
+     * )
      */
     public function show(Problema $problema)
     {
@@ -43,7 +115,16 @@ class ProblemaController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
+     * @OA\Put(
+     *      path="/api/problemas/{problema}",
+     *      operationId="updateProblema",
+     *      tags={"Problemas"},
+     *      summary="Atualiza um problema (Não implementado)",
+     *      deprecated=true,
+     *      description="Este endpoint ainda não foi implementado.",
+     *      @OA\Parameter(name="problema", in="path", required=true, @OA\Schema(type="integer")),
+     *      @OA\Response(response=501, description="Não implementado")
+     * )
      */
     public function update(Request $request, Problema $problema)
     {
@@ -52,12 +133,33 @@ class ProblemaController extends Controller
     public function teste(){
 
     }
+
     /**
-     * Remove the specified resource from storage.
+     * @OA\Delete(
+     *      path="/api/problemas/{problema}",
+     *      operationId="deleteProblema",
+     *      tags={"Problemas"},
+     *      summary="Remove um problema",
+     *      description="Apaga um problema e seus dados associados do banco de dados.",
+     *      @OA\Parameter(
+     *          name="problema",
+     *          in="path",
+     *          required=true,
+     *          description="ID do problema a ser removido",
+     *          @OA\Schema(type="integer")
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Removido com sucesso",
+     *          @OA\JsonContent(type="string", example="Apagado com sucesso!")
+     *      ),
+     *      @OA\Response(response=400, description="Erro ao apagar"),
+     *      @OA\Response(response=404, description="Problema não encontrado")
+     * )
      */
     public function destroy(Problema $problema)
     {
-         try{
+        try{
             $problema->delete();
         } catch(Exception $e){
             return response()->json(['Erro ao apagar.'], 400);

--- a/src/app/Http/Controllers/SubmissaoController.php
+++ b/src/app/Http/Controllers/SubmissaoController.php
@@ -8,10 +8,30 @@ use Exception;
 use Illuminate\Http\Request;
 use Throwable;
 
+/**
+ * @OA\Tag(
+ *     name="Submissões",
+ *     description="Endpoints para gerenciar submissões de código."
+ * )
+ */
 class SubmissaoController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * @OA\Get(
+     *      path="/api/submissoes",
+     *      operationId="getSubmissoesList",
+     *      tags={"Submissões"},
+     *      summary="Lista todas as submissões",
+     *      description="Retorna um array com todas as submissões registradas no sistema.",
+     *      @OA\Response(
+     *          response=200,
+     *          description="Operação bem-sucedida",
+     *          @OA\JsonContent(
+     *              type="array",
+     *              @OA\Items(ref="#/components/schemas/Submissao")
+     *          )
+     *       )
+     * )
      */
     public function index()
     {
@@ -21,8 +41,39 @@ class SubmissaoController extends Controller
     }
 
     /**
-     * Store a newly created resource in storage.
-     * @throws Throwable
+     * @OA\Post(
+     *      path="/api/submissoes",
+     *      operationId="storeSubmissao",
+     *      tags={"Submissões"},
+     *      summary="Cria uma nova submissão",
+     *      description="Envia um código para ser avaliado em uma atividade específica.",
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="Dados para a criação da submissão",
+     *          @OA\JsonContent(
+     *              required={"codigo", "atividade_id"},
+     *              @OA\Property(property="codigo", type="string", description="O código-fonte a ser avaliado.", example="def soma(a, b):\n    return a + b"),
+     *              @OA\Property(property="atividade_id", type="integer", description="O ID da atividade à qual o código se refere.", example=1)
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="Submissão criada com sucesso",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="Submissão criada com sucesso!"),
+     *              @OA\Property(property="submissao", type="object",
+     *                  @OA\Property(property="id", type="integer", example=123)
+     *              )
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Erro ao salvar submissao",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="Erro ao salvar submissao")
+     *          )
+     *      )
+     * )
      */
     public function store(Request $request)
     {
@@ -39,7 +90,44 @@ class SubmissaoController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * @OA\Get(
+     *      path="/api/submissoes/{id}",
+     *      operationId="getSubmissaoStatus",
+     *      tags={"Submissões"},
+     *      summary="Obtém o status de uma submissão",
+     *      description="Verifica o resultado da avaliação de uma submissão pelo seu ID.",
+     *      @OA\Parameter(
+     *          name="id",
+     *          in="path",
+     *          required=true,
+     *          description="ID da submissão",
+     *          @OA\Schema(type="integer")
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Status da submissão retornado com sucesso",
+     *          @OA\JsonContent(
+     *              type="object",
+     *              @OA\Property(
+     *                  property="status",
+     *                  type="string",
+     *                  description="Descrição do status atual da correção.",
+     *                  enum={"Na Fila", "Em Processamento", "Aceita", "Resposta Errada", "Tempo Limite Excedido", "Erro de Compilação", "Erro de Execução (SIGSEGV)", "Erro de Execução (SIGXFSZ)", "Erro de Execução (SIGFPE)", "Erro de Execução (SIGABRT)", "Erro de Execução (NZEC)", "Erro de Execução", "Erro Interno", "Erro no Formato de Execução"},
+     *                  example="Aceita"
+     *              ),
+     *              @OA\Property(property="erro_teste", type="integer", nullable=true, description="ID do caso de teste que falhou (se aplicável).", example=3),
+     *              @OA\Property(property="erro", type="string", nullable=true, description="Mensagem de erro de compilação (se aplicável e decodificada).", example="SyntaxError: invalid syntax")
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Submissão não encontrada"
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Erro interno ao buscar o status"
+     *      )
+     * )
      */
     public function show(Submissao $submissao)
     {

--- a/src/app/Models/Atividade.php
+++ b/src/app/Models/Atividade.php
@@ -4,6 +4,35 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @OA\Schema(
+ *     schema="Atividade",
+ *     type="object",
+ *     title="Atividade Model",
+ *     properties={
+ *         @OA\Property(property="id", type="integer", readOnly="true", example=1),
+ *         @OA\Property(property="data_entrega", type="string", format="date-time", description="Prazo final para a entrega da atividade", example="2024-05-20T23:59:59Z"),
+ *         @OA\Property(property="problema_id", type="integer", description="ID do problema associado a esta atividade", example=1),
+ *         @OA\Property(property="created_at", type="string", format="date-time", readOnly="true"),
+ *         @OA\Property(property="updated_at", type="string", format="date-time", readOnly="true")
+ *     }
+ * )
+ *
+ * @OA\Schema(
+ *     schema="AtividadeComProblema",
+ *     title="Atividade com Problema Detalhado",
+ *     description="Representa uma atividade completa com os dados do problema aninhados.",
+ *     allOf={
+ *         @OA\Schema(ref="#/components/schemas/Atividade"),
+ *         @OA\Schema(
+ *             type="object",
+ *             properties={
+ *                 @OA\Property(property="problema", ref="#/components/schemas/Problema")
+ *             }
+ *         )
+ *     }
+ * )
+ */
 class Atividade extends Model
 {
     protected $table = 'atividade';

--- a/src/app/Models/CasoTeste.php
+++ b/src/app/Models/CasoTeste.php
@@ -5,6 +5,21 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @OA\Schema(
+ *     schema="CasoTeste",
+ *     type="object",
+ *     title="Caso de Teste Model",
+ *     description="Representa um único caso de teste para um problema, com entrada e saída esperada.",
+ *     properties={
+ *         @OA\Property(property="id", type="integer", readOnly="true", example=1),
+ *         @OA\Property(property="entrada", type="string", description="Dados de entrada para o caso de teste.", example="5\n10"),
+ *         @OA\Property(property="saida", type="string", description="Saída esperada para a entrada fornecida.", example="15"),
+ *         @OA\Property(property="privado", type="boolean", description="Indica se o caso de teste é visível para o usuário (false) ou oculto (true).", example=false),
+ *         @OA\Property(property="problema_id", type="integer", readOnly="true", description="ID do problema ao qual o caso de teste pertence.", example=1)
+ *     }
+ * )
+ */
 class CasoTeste extends Model
 {
     use HasFactory;

--- a/src/app/Models/Problema.php
+++ b/src/app/Models/Problema.php
@@ -5,6 +5,41 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @OA\Schema(
+ *     schema="Problema",
+ *     type="object",
+ *     title="Problema Model",
+ *     properties={
+ *         @OA\Property(property="id", type="integer", readOnly="true", example=1),
+ *         @OA\Property(property="titulo", type="string", description="Título do problema.", example="Soma de Dois Números"),
+ *         @OA\Property(property="enunciado", type="string", format="textarea", description="Descrição completa do problema.", example="Leia dois valores inteiros e imprima a soma."),
+ *         @OA\Property(property="tempo_limite", type="integer", description="Tempo limite de execução em segundos.", example=1),
+ *         @OA\Property(property="memoria_limite", type="integer", description="Limite de memória em KB.", example=512),
+ *         @OA\Property(property="created_at", type="string", format="date-time", readOnly="true"),
+ *         @OA\Property(property="updated_at", type="string", format="date-time", readOnly="true")
+ *     }
+ * )
+ *
+ * @OA\Schema(
+ *     schema="ProblemaComCasosTeste",
+ *     title="Problema com Casos de Teste",
+ *     description="Representa um problema completo com seus casos de teste aninhados.",
+ *     allOf={
+ *         @OA\Schema(ref="#/components/schemas/Problema"),
+ *         @OA\Schema(
+ *             type="object",
+ *             properties={
+ *                 @OA\Property(
+ *                     property="casos_teste",
+ *                     type="array",
+ *                     @OA\Items(ref="#/components/schemas/CasoTeste")
+ *                 )
+ *             }
+ *         )
+ *     }
+ * )
+ */
 class Problema extends Model
 {
     use HasFactory;

--- a/src/app/Models/Submissao.php
+++ b/src/app/Models/Submissao.php
@@ -6,6 +6,23 @@ use App\Facades\Judge0;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @OA\Schema(
+ *     schema="Submissao",
+ *     type="object",
+ *     title="Submissao Model",
+ *     description="Representa uma submissão de código de uma atividade.",
+ *     properties={
+ *         @OA\Property(property="id", type="integer", readOnly="true", example=1),
+ *         @OA\Property(property="data_submissao", type="string", format="date-time", readOnly="true", example="2023-10-27T10:00:00Z"),
+ *         @OA\Property(property="codigo", type="string", description="Código fonte submetido pelo usuário.", example="print('Hello, World!')"),
+ *         @OA\Property(property="linguagem", type="string", description="Linguagem de programação utilizada (definida no backend).", example="python"),
+ *         @OA\Property(property="atividade_id", type="integer", description="ID da atividade relacionada.", example=101),
+ *         @OA\Property(property="created_at", type="string", format="date-time", readOnly="true", example="2023-10-27T10:00:00Z"),
+ *         @OA\Property(property="updated_at", type="string", format="date-time", readOnly="true", example="2023-10-27T10:00:00Z")
+ *     }
+ * )
+ */
 class Submissao extends Model
 {
     protected $table = 'submissao';
@@ -45,5 +62,4 @@ class Submissao extends Model
         }
         return $resposta;
     }
-
 }

--- a/src/composer.json
+++ b/src/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "darkaonline/l5-swagger": "^8.6",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c491b8531eec05ba41a11d9276a5749",
+    "content-hash": "40cc7c8e54f7c636843262ae328d50a4",
     "packages": [
         {
             "name": "brick/math",
@@ -136,6 +136,86 @@
             "time": "2023-12-11T17:09:12+00:00"
         },
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "8.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "4cf2b3faae9e9cffd05e4eb6e066741bf56f0a85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/4cf2b3faae9e9cffd05e4eb6e066741bf56f0a85",
+                "reference": "4cf2b3faae9e9cffd05e4eb6e066741bf56f0a85",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "laravel/framework": "^11.0 || ^10.0 || ^9.0 || >=8.40.0 || ^7.0",
+                "php": "^7.2 || ^8.0",
+                "swagger-api/swagger-ui": "^3.0 || >=4.1.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
+                "zircote/swagger-php": "^3.2.0 || ^4.0.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^11.0 || ^10.0 || ^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/8.6.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-06T14:54:32+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
             "source": {
@@ -209,6 +289,82 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -2469,6 +2625,55 @@
             "time": "2024-07-20T21:41:07+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3155,6 +3360,67 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
             "time": "2025-06-25T14:20:11+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.27.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "43ed706e9519841e97401cfad83faca564b37eaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/43ed706e9519841e97401cfad83faca564b37eaf",
+                "reference": "43ed706e9519841e97401cfad83faca564b37eaf",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.27.1"
+            },
+            "time": "2025-08-01T07:33:59+00:00"
         },
         {
             "name": "symfony/console",
@@ -5375,6 +5641,82 @@
             "time": "2025-07-29T18:40:01+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v6.4.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "742a8efc94027624b36b10ba58e23d402f961f51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/742a8efc94027624b36b10ba58e23d402f961f51",
+                "reference": "742a8efc94027624b36b10ba58e23d402f961f51",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v6.4.24"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:14:14+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.3.0",
             "source": {
@@ -5644,6 +5986,87 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "4.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "7df10e8ec47db07c031db317a25bef962b4e5de1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/7df10e8ec47db07c031db317a25bef962b4e5de1",
+                "reference": "7df10e8ec47db07c031db317a25bef962b4e5de1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": ">=2.2",
+                "symfony/yaml": ">=3.3"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^1.7 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^2.17 || 3.62.0",
+                "phpstan/phpstan": "^1.6",
+                "phpunit/phpunit": ">=8",
+                "vimeo/psalm": "^4.23"
+            },
+            "suggest": {
+                "doctrine/annotations": "^1.7 || ^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "swagger-php - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/4.11.1"
+            },
+            "time": "2024-10-15T19:20:02+00:00"
         }
     ],
     "packages-dev": [
@@ -8045,82 +8468,6 @@
             "time": "2025-02-20T13:13:55+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v6.4.24",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "742a8efc94027624b36b10ba58e23d402f961f51"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/742a8efc94027624b36b10ba58e23d402f961f51",
-                "reference": "742a8efc94027624b36b10ba58e23d402f961f51",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<5.4"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4|^6.0|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.24"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-10T08:14:14+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -8173,12 +8520,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/config/l5-swagger.php
+++ b/src/config/l5-swagger.php
@@ -1,0 +1,318 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                 */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                 */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('APP_URL', 'http://localhost'),
+        ],
+    ],
+];

--- a/src/resources/views/vendor/l5-swagger/index.blade.php
+++ b/src/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{config('l5-swagger.documentations.'.$documentation.'.api.title')}}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+    @if(config('l5-swagger.defaults.ui.display.dark_mode'))
+        <style>
+            body#dark-mode,
+            #dark-mode .scheme-container {
+                background: #1b1b1b;
+            }
+            #dark-mode .scheme-container,
+            #dark-mode .opblock .opblock-section-header{
+                box-shadow: 0 1px 2px 0 rgba(255, 255, 255, 0.15);
+            }
+            #dark-mode .operation-filter-input,
+            #dark-mode .dialog-ux .modal-ux,
+            #dark-mode input[type=email],
+            #dark-mode input[type=file],
+            #dark-mode input[type=password],
+            #dark-mode input[type=search],
+            #dark-mode input[type=text],
+            #dark-mode textarea{
+                background: #343434;
+                color: #e7e7e7;
+            }
+            #dark-mode .title,
+            #dark-mode li,
+            #dark-mode p,
+            #dark-mode table,
+            #dark-mode label,
+            #dark-mode .opblock-tag,
+            #dark-mode .opblock .opblock-summary-operation-id,
+            #dark-mode .opblock .opblock-summary-path,
+            #dark-mode .opblock .opblock-summary-path__deprecated,
+            #dark-mode h1,
+            #dark-mode h2,
+            #dark-mode h3,
+            #dark-mode h4,
+            #dark-mode h5,
+            #dark-mode .btn,
+            #dark-mode .tab li,
+            #dark-mode .parameter__name,
+            #dark-mode .parameter__type,
+            #dark-mode .prop-format,
+            #dark-mode .loading-container .loading:after{
+                color: #e7e7e7;
+            }
+            #dark-mode .opblock-description-wrapper p,
+            #dark-mode .opblock-external-docs-wrapper p,
+            #dark-mode .opblock-title_normal p,
+            #dark-mode .response-col_status,
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th,
+            #dark-mode .response-col_links,
+            #dark-mode .swagger-ui{
+                color: wheat;
+            }
+            #dark-mode .parameter__extension,
+            #dark-mode .parameter__in,
+            #dark-mode .model-title{
+                color: #949494;
+            }
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th{
+                border-color: rgba(120,120,120,.2);
+            }
+            #dark-mode .opblock .opblock-section-header{
+                background: transparent;
+            }
+            #dark-mode .opblock.opblock-post{
+                background: rgba(73,204,144,.25);
+            }
+            #dark-mode .opblock.opblock-get{
+                background: rgba(97,175,254,.25);
+            }
+            #dark-mode .opblock.opblock-put{
+                background: rgba(252,161,48,.25);
+            }
+            #dark-mode .opblock.opblock-delete{
+                background: rgba(249,62,62,.25);
+            }
+            #dark-mode .loading-container .loading:before{
+                border-color: rgba(255,255,255,10%);
+                border-top-color: rgba(255,255,255,.6);
+            }
+            #dark-mode svg:not(:root){
+                fill: #e7e7e7;
+            }
+            #dark-mode .opblock-summary-description {
+                color: #fafafa;
+            }
+        </style>
+    @endif
+</head>
+
+<body @if(config('l5-swagger.defaults.ui.display.dark_mode')) id="dark-mode" @endif>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            url: "{!! $urlToDocs !!}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -15,10 +15,11 @@ use Illuminate\Support\Facades\Route;
 | be assigned to the "api" middleware group. Make something great!
 |
 */
-Route::apiResource('atividade', AtividadeController::class);
-Route::apiResource('problema', ProblemaController::class);
-Route::apiResource('submissao', SubmissaoController::class)
-->except('update', 'destroy');
+Route::apiResource('atividades', AtividadeController::class);
+Route::apiResource('problemas', ProblemaController::class);
+Route::apiResource('submissoes', SubmissaoController::class)
+->except('update', 'destroy')
+->parameters(['submissoes' => 'submissao']);;
 
 // Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 //     return $request->user();


### PR DESCRIPTION
Esse PR adiciona o pacote darkaonline/l5-swagger como dependência do sistema para documentar as rotas do sistema.

Para configurar o pacote localmente execute os comandos:
```bash
composer install
php artisan optimize:clear
php artisan l5-swagger:generate
```

Certifique-se que a variável de ambiente APP_URL está definida com o valor correto.